### PR TITLE
Automate re-creation of 'Social Following+Share' Issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/social-following-and-share.md
+++ b/.github/ISSUE_TEMPLATE/social-following-and-share.md
@@ -1,6 +1,6 @@
 ---
 name: Social following and share
-about: Use this to re-create the Social Following and share issue
+about: Use this to create a 'Social following and share' issue
 title: Social following and share
 labels: good first issue
 assignees: ''
@@ -9,19 +9,15 @@ assignees: ''
 
 ### Purpose & Details
 
-By following us on social channels and sharing our content you will help us spread the word about InnerSource, grow our channels and reach more audiences. 
+By following us on social channels and sharing our content you will help us spread the word about InnerSource, grow our channels and reach more audiences.
 
 ### Acceptance Criteria
 
-- Follow InnerSource Commons on social media.
-- Follow on Twitter: [@InnerSourceOrg](http://twitter.com/InnerSourceOrg)
-- Follow on LinkedIn: [InnerSource Commons Foundation](https://linkedin.com/company/innersourcecommons)
-- Subscribe on Youtube: [InnerSource Commons](https://www.youtube.com/channel/UCoSPSd6Or4F_vpjo4SmyoEA)
-- Share our latest posts
-- Once you have done so, please:
-        - Close this issue
-        - Open a new issue based on the template "Social following and share"
-        - Before saving make sure to add the issue to the Marketing WG Board in the Project section on the right. Once you have done this, you will see a dropdown box under the green bar within the Project: "Awaiting triage".
-        - Please change "Awaiting Triage" to "To Do"
+- [ ] Follow InnerSource Commons on social media.
+  - [ ] Follow on Twitter: [@InnerSourceOrg](http://twitter.com/InnerSourceOrg)
+  - [ ] Follow on LinkedIn: [InnerSource Commons Foundation](https://linkedin.com/company/innersourcecommons)
+  - [ ] Subscribe on Youtube: [InnerSource Commons](https://www.youtube.com/channel/UCoSPSd6Or4F_vpjo4SmyoEA)
+- [ ] Share some of our latest posts
+- [ ] Once you have done so, close this issue
 
-This will allow us to keep track of and acknowledge your contribution and it will give the chance to the next person that is interested in contributing to pick up this issue.
+Thank you for helping us to spread the word about InnerSource!

--- a/.github/workflows/auto-create-social-following-and-share.yml
+++ b/.github/workflows/auto-create-social-following-and-share.yml
@@ -1,0 +1,30 @@
+# Found the issue-bot GHA used in this GitHub documentation: https://docs.github.com/en/actions/guides/scheduling-issue-creation
+# https://github.com/marketplace/actions/issue-bot-action
+# https://github.com/marketplace/actions/extract-issue-template-fields
+name: IssueOps - Create issue for "Social following and share" once the previous issues is closed
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  build:
+    if:  startsWith(github.event.issue.title, 'Social following and share')
+    runs-on: ubuntu-latest
+    steps:
+    # Get the title, labels, assignees, and body of the issue template at the given path
+    - uses: imjohnbo/extract-issue-template-fields@v1
+      id: extract
+      with:
+        path: .github/ISSUE_TEMPLATE/social-following-and-share.md
+
+    # Create new issue with assignees, labels, title, and body.
+    # Also place the new issue in project #1, column "To Do"
+    - uses: imjohnbo/issue-bot@v3
+      with:
+        assignees: ${{ steps.extract.outputs.assignees }}
+        labels: ${{ steps.extract.outputs.labels }}
+        title: ${{ steps.extract.outputs.title }}
+        body: ${{ steps.extract.outputs.body }}
+        project: 1
+        column: "To do"


### PR DESCRIPTION
Implements #85 

- Adding workflow to automatically re-create the 'Social following and share' issue and place it onto the correct project board.
- Modifying template - removing manual issue creation instructions. Also turning bullets into checklist.
