### PR TITLE
Post Community Call templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/community-call-anonymised-discussion.md
+++ b/.github/ISSUE_TEMPLATE/community-call-anonymised-discussion.md
@@ -1,0 +1,21 @@
+---
+name: Community Call Anonymised Discussion
+about: Use this to create an issue for anonymising the community call discussion document
+  as per Chatham House rule
+title: Create Community Call Anonymised discussion document
+labels: good first issue, events
+assignees: ''
+
+---
+
+### Purpose & Details
+Create the anonymised version of the Community Call discussion document as per Chatham House Rule so that it can be shared with the community and content can be created based on it.
+
+### Acceptance Criteria
+- [ ] We have created a new document in the relevant event folder in the [Marketing drive](https://drive.google.com/drive/u/0/folders/1RTUKX2wor2IucJbnUgt5MpMyvsCWM7j6)
+- [ ] We have transferred the content from the original document.
+- [ ] We have removed all people and company names from the document 
+- [ ] We have shared the anonymised document in the Marketing slack channel
+
+Note:
+If you pick up this issue, please ask in the Marketing channel to be given access to the original Community Call discussion document.

--- a/.github/ISSUE_TEMPLATE/community-call-anonymised-discussion.md
+++ b/.github/ISSUE_TEMPLATE/community-call-anonymised-discussion.md
@@ -1,7 +1,6 @@
 ---
 name: Community Call Anonymised Discussion
-about: Use this to create an issue for anonymising the community call discussion document
-  as per Chatham House rule
+about: Use this to create an issue for anonymising the community call discussion document as per Chatham House rule
 title: Create Community Call Anonymised discussion document
 labels: good first issue, events
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/community-call-anonymised-discussion.md
+++ b/.github/ISSUE_TEMPLATE/community-call-anonymised-discussion.md
@@ -4,7 +4,6 @@ about: Use this to create an issue for anonymising the community call discussion
 title: Create Community Call Anonymised discussion document
 labels: good first issue, events
 assignees: ''
-
 ---
 
 ### Purpose & Details

--- a/.github/ISSUE_TEMPLATE/community-call-infographic.md
+++ b/.github/ISSUE_TEMPLATE/community-call-infographic.md
@@ -1,0 +1,18 @@
+---
+name: Community Call Infographic
+about: Use this to create an issue asking for an infographic to be created
+title: 'Community Call Takeaways Infographic '
+labels: events
+assignees: ''
+
+---
+
+Purpose & Details
+Create an infographic based on the Comunity Call Takeaways document. 
+
+Acceptance Criteria
+ - [ ] We have checked in the Marketing Slack channel for the community call takeaways document.
+ - [ ] We have produced an infographic based on the content in the article.
+ - [ ] We have shared the infographic for review on the Marketing channel
+ - [ ] We have implemented the feedback received
+ - [ ] We have shared the updated Infographic in the Marketing Slack channel.

--- a/.github/ISSUE_TEMPLATE/community-call-infographic.md
+++ b/.github/ISSUE_TEMPLATE/community-call-infographic.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-Purpose & Details
+### Purpose & Details
 Create an infographic based on the Comunity Call Takeaways document. 
 
 Acceptance Criteria

--- a/.github/ISSUE_TEMPLATE/community-call-infographic.md
+++ b/.github/ISSUE_TEMPLATE/community-call-infographic.md
@@ -10,7 +10,7 @@ assignees: ''
 ### Purpose & Details
 Create an infographic based on the Comunity Call Takeaways document. 
 
-Acceptance Criteria
+### Acceptance Criteria
  - [ ] We have checked in the Marketing Slack channel for the community call takeaways document.
  - [ ] We have produced an infographic based on the content in the article.
  - [ ] We have shared the infographic for review on the Marketing channel

--- a/.github/ISSUE_TEMPLATE/community-call-infographic.md
+++ b/.github/ISSUE_TEMPLATE/community-call-infographic.md
@@ -4,7 +4,6 @@ about: Use this to create an issue asking for an infographic to be created
 title: 'Community Call Takeaways Infographic '
 labels: events
 assignees: ''
-
 ---
 
 ### Purpose & Details

--- a/.github/ISSUE_TEMPLATE/community-call-takeaways.md
+++ b/.github/ISSUE_TEMPLATE/community-call-takeaways.md
@@ -10,7 +10,7 @@ assignees: ''
 ### Purpose & Details
 Create a shareable list of insights from our last Community Call discussion. These insights will be used to create content for our social channels.
 
-Acceptance Criteria
+### Acceptance Criteria
  - [ ] We have checked the Marketing Slack channel for the community call anonymised discussion document.
  - [ ] We have produced an article detailing the takeaways from the community call in Google Drive.
  - [ ] We have shared the draft in the Marketing channel on Slack asking people to contribute/ provide feedback on the document

--- a/.github/ISSUE_TEMPLATE/community-call-takeaways.md
+++ b/.github/ISSUE_TEMPLATE/community-call-takeaways.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-Purpose & Details
+### Purpose & Details
 Create a shareable list of insights from our last Community Call discussion. These insights will be used to create content for our social channels.
 
 Acceptance Criteria

--- a/.github/ISSUE_TEMPLATE/community-call-takeaways.md
+++ b/.github/ISSUE_TEMPLATE/community-call-takeaways.md
@@ -1,0 +1,20 @@
+---
+name: Community Call Takeaways
+about: Use this issue to request the creation of a document on Community Call takeaways
+title: Community Call Takeaways
+labels: good first issue, events
+assignees: ''
+
+---
+
+Purpose & Details
+Create a shareable list of insights from our last Community Call discussion. These insights will be used to create content for our social channels.
+
+Acceptance Criteria
+ - [ ] We have checked the Marketing Slack channel for the community call anonymised discussion document.
+ - [ ] We have produced an article detailing the takeaways from the community call in Google Drive.
+ - [ ] We have shared the draft in the Marketing channel on Slack asking people to contribute/ provide feedback on the document
+ - [ ] We have implemented the feedback
+ - [ ] We have created an article on LinkedIn and shared it with InnerSource Commons 
+        - [ ] Please share the article on Linkedin and tag InnerSource Commons
+        - [ ] Please share a link to the article in the Marketing Slack channel

--- a/.github/ISSUE_TEMPLATE/community-call-takeaways.md
+++ b/.github/ISSUE_TEMPLATE/community-call-takeaways.md
@@ -4,7 +4,6 @@ about: Use this issue to request the creation of a document on Community Call ta
 title: Community Call Takeaways
 labels: good first issue, events
 assignees: ''
-
 ---
 
 ### Purpose & Details

--- a/.github/ISSUE_TEMPLATE/share-content-on-social-channels.md
+++ b/.github/ISSUE_TEMPLATE/share-content-on-social-channels.md
@@ -1,7 +1,6 @@
 ---
 name: Share content on social channels
-about: Use this to let the marketing team know about content we should share on social
-  channels
+about: Use this to let the marketing team know about content we should share on social channels
 title: Share content on social channels
 labels: ISC OPS
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/share-content-on-social-channels.md
+++ b/.github/ISSUE_TEMPLATE/share-content-on-social-channels.md
@@ -6,7 +6,7 @@ labels: ISC OPS
 assignees: ''
 ---
 
-Purpose & Details
+### Purpose & Details
 Share content with our followers on social media.
 
 Content to be shared

--- a/.github/ISSUE_TEMPLATE/share-content-on-social-channels.md
+++ b/.github/ISSUE_TEMPLATE/share-content-on-social-channels.md
@@ -4,7 +4,6 @@ about: Use this to let the marketing team know about content we should share on 
 title: Share content on social channels
 labels: ISC OPS
 assignees: ''
-
 ---
 
 Purpose & Details

--- a/.github/ISSUE_TEMPLATE/share-content-on-social-channels.md
+++ b/.github/ISSUE_TEMPLATE/share-content-on-social-channels.md
@@ -10,7 +10,7 @@ assignees: ''
 Share content with our followers on social media.
 
 Content to be shared
-[Plese attach the infographic to this issue or include any content you would like us to share on Linkedin and Twitter here]
+[Please attach the infographic to this issue or include any content you would like us to share on Linkedin and Twitter here]
 
-Acceptance Criteria
+### Acceptance Criteria
  - [ ] We have shared the content on Twitter and LinkedIn.

--- a/.github/ISSUE_TEMPLATE/share-content-on-social-channels.md
+++ b/.github/ISSUE_TEMPLATE/share-content-on-social-channels.md
@@ -1,0 +1,18 @@
+---
+name: Share content on social channels
+about: Use this to let the marketing team know about content we should share on social
+  channels
+title: Share content on social channels
+labels: ISC OPS
+assignees: ''
+
+---
+
+Purpose & Details
+Share content with our followers on social media.
+
+Content to be shared
+[Plese attach the infographic to this issue or include any content you would like us to share on Linkedin and Twitter here]
+
+Acceptance Criteria
+ - [ ] We have shared the content on Twitter and LinkedIn.


### PR DESCRIPTION
I added 4 issue templates for actions to be taken after the Community Call:
 - anonymizing the discussion document
 - creating the Takeaways from the Community Call discussion. 
 - creating the infographic based on the takeaways 
 - sharing the content/infographic on social channels.