### PR TITLE
Automatically pin the 'Social following and share' issue on re-creation.

### DIFF
--- a/.github/workflows/auto-create-social-following-and-share.yml
+++ b/.github/workflows/auto-create-social-following-and-share.yml
@@ -12,6 +12,7 @@ jobs:
     if:  startsWith(github.event.issue.title, 'Social following and share')
     runs-on: ubuntu-latest
     steps:
+      
     # Get the title, labels, assignees, and body of the issue template at the given path
     - uses: imjohnbo/extract-issue-template-fields@v1
       id: extract

--- a/.github/workflows/auto-create-social-following-and-share.yml
+++ b/.github/workflows/auto-create-social-following-and-share.yml
@@ -28,3 +28,4 @@ jobs:
         body: ${{ steps.extract.outputs.body }}
         project: 1
         column: "To do"
+        pinned: true


### PR DESCRIPTION
 Configuring GHA to automatically pin the 'Social following and share' issue on re-creation.

To merge this PR we need to wait for an updated version of the `imjohnbo/issue-bot`, which contains a fix to the issue pinning feature that we need.