### PR TITLE
ISC Gathering Lead Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/isc-gathering-lead.md
+++ b/.github/ISSUE_TEMPLATE/isc-gathering-lead.md
@@ -1,0 +1,55 @@
+---
+name: ISC Gathering Lead
+about: Steps of an ISC Gathering Lead
+title: "[CONFERENCE_NAME] [CONFERENCE_DATE(S)]"
+labels: Gathering Lead
+assignees: ''
+
+---
+
+Thank you for being an ISC Gathering Lead!
+The purpose of this role is to build the ISC community while at 3rd-party events by:
+* Connecting together ISC community members who are at the event.
+* Letting others know about the ISC and inviting them to participate.
+
+Follow these steps to accomplish these goals.
+Check them off as you go!
+Feel free to add any more ideas that you have!
+
+# Immediately
+- [ ] Fill in the conference name and dates as in the title.
+- [ ] Assign this issue to yourself.
+
+# 4 Weeks Prior
+- [ ] Introduce yourself in the [#marketing] channel and ask for some ISC stickers to be shipped to you.
+- [ ] Create a new channel in the [InnerSource Commons Slack] specifically for your conference.
+Format is `#event-[conference_name]-[year]`.
+- [ ] Let people know in the [#general] channel about the conference.
+Encourage them to attend and to join your new Slack channel
+
+# 2 Weeks Prior
+- [ ] Plan some type of in-person get-together for ISC attendees.
+It could be as simple as meeting at a specified location for lunch during the conference or a dinner the night before.
+- [ ] Let everyone know in the event channel what is the get-together plan.
+- [ ] Remind people in the [#general] channel about the conference and your Slack channel.
+
+# 1 Week Prior
+- [ ] Remind everyone of the get-together plan.
+- [ ] Pack the ISC stickers.
+- [ ] Remind people in the [#general] channel about the conference and your Slack channel.
+
+# Conference Day(s)
+- [ ] Remind everyone of the get-together plan.
+- [ ] Hold the get-together.
+- [ ] Hand out ISC stickers wherever you can.
+- [ ] If you meet anyone feels InnerSource-related, invite them to join the [InnerSource Commons Slack].
+- [ ] Have fun at the conference!
+
+# Week After
+- [ ] Share back in the [#marketing] channel how your experience went.
+Better, yet, attend a [#marketing] working group meeting and share on the call!
+
+
+[#general]: https://app.slack.com/client/T04PXKRM0/C04PXKRN4
+[InnerSource Commons Slack]: https://app.slack.com/client/T04PXKRM0
+[#marketing]: https://app.slack.com/client/T04PXKRM0/CUWFGQJ8K


### PR DESCRIPTION
This is a template that can be used to create an issue with checkboxes for the steps of being an ISC Gathering Lead.  You can see what it (mostly) looks like [here](https://github.com/InnerSourceCommons/InnerSourceMarketing/blob/rrrutledge-patch-2/.github/ISSUE_TEMPLATE/isc-gathering-lead.md).